### PR TITLE
fix url ref used for clipPathId

### DIFF
--- a/lib/sparklines/SparklinesComposed/SparklinesComposed.tsx
+++ b/lib/sparklines/SparklinesComposed/SparklinesComposed.tsx
@@ -140,7 +140,7 @@ const SparklinesComposedInner = <TData,>(
             ...childProps,
             ...internalShapeProps,
             key: i,
-            clipPathId: `url(${clipId})`,
+            clipPathId: `url(#${clipId})`,
           });
         }
         return null;


### PR DESCRIPTION
Fixes https://github.com/Lueton/react-sparklines/issues/12